### PR TITLE
fix: add missing build steps to PyPI publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,12 +8,22 @@ jobs:
   pypi-publish:
     name: upload release to PyPI
     runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
     environment: pypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
     steps:
-      # retrieve your distributions here
+      - uses: actions/checkout@v4
+      
+      - name: Setup uv python package manager
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          
+      - name: Build package distributions
+        run: |
+          uv build
+          
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## 🐛 Fix PyPI Publish Workflow

### Problem
The PyPI publish workflow was failing with the error:
> "It looks like there are no Python distribution packages to publish in the directory 'dist/'"

This happened because the workflow was missing the essential build steps before attempting to publish.

### Solution
Added the missing steps to the workflow:

1. **Checkout source code** (`actions/checkout@v4`)
2. **Setup Python environment** (`astral-sh/setup-uv@v6`) - consistent with CI workflow
3. **Build distributions** (`uv build`) - creates wheel and sdist in `dist/` directory

### Changes Made
- ✅ Added `actions/checkout@v4` step
- ✅ Added `astral-sh/setup-uv@v6` setup with Python 3.12
- ✅ Added `uv build` command to create distribution packages
- ✅ Maintained existing Trusted Publishing configuration

### Testing
This fix addresses the root cause identified in the failed workflow run: https://github.com/fcakyon/trackio-mcp/actions/runs/16705165579/job/47282173815

### Requirements
Ensure **Trusted Publishing** is configured on PyPI:
1. Go to project settings on PyPI
2. Add pending publisher with:
   - Repository: `fcakyon/trackio-mcp`
   - Workflow: `publish_pypi.yml`
   - Environment: `pypi`

Closes the issue preventing successful PyPI releases.