### PR TITLE
docs: add missing environment variable prerequisites to MCP client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ Agent: Your latest image-classification run achieved 94.2% accuracy with a final
 
 ## MCP Client Configuration
 
+### Prerequisites
+
+**⚠️ Important**: Before configuring your MCP client, ensure the MCP server is enabled:
+
+```bash
+# Set environment variable to enable MCP (default: "true")
+export TRACKIO_ENABLE_MCP="true"
+
+# Alternative environment variable
+export GRADIO_MCP_SERVER="true"
+```
+
+Or in your Python code:
+
+```python
+import os
+os.environ["TRACKIO_ENABLE_MCP"] = "true"  # Enable MCP
+import trackio_mcp  # Must import before trackio
+import trackio
+```
+
+Without these environment variables, the MCP server won't be available even with correct client configuration.
+
 ### Claude Desktop & Gemini CLI & Claude Code
 
 These clients use similar JSON configuration structures with `mcpServers`:


### PR DESCRIPTION
This PR fixes a critical gap in the README documentation. The MCP client configuration examples were missing the crucial server-side environment variable setup needed for the MCP server to actually be enabled.

## Problem
Users could configure their MCP clients perfectly but still have connection failures because the MCP server wasn't enabled on the trackio side due to missing environment variables.

## Solution
Added a **Prerequisites** section to the MCP Client Configuration with:

- ⚠️ Warning about environment variable requirement
- Clear examples of setting `TRACKIO_ENABLE_MCP="true"` 
- Alternative `GRADIO_MCP_SERVER="true"` option
- Python code example showing proper import order
- Explicit warning that MCP server won't work without these variables

## Changes
- Added Prerequisites subsection to MCP Client Configuration
- No changes to existing client configuration examples
- Maintains all existing functionality while preventing user confusion

This ensures users understand they need both:
1. ✅ Server-side environment variables (now documented)
2. ✅ Client-side JSON configuration (already documented)